### PR TITLE
chore(ci): Add CI/CD GitHub Actions workflows

### DIFF
--- a/.github/instructions/commandcenter-build-and-test.instructions.md
+++ b/.github/instructions/commandcenter-build-and-test.instructions.md
@@ -48,6 +48,16 @@ npm run verify       # lint + test + compile
 
 **Run `npm run verify` before every PR and commit.**
 
+## CI pipeline
+
+GitHub Actions CI (`.github/workflows/ci.yml`) runs the same quality gate automatically:
+
+- **Trigger**: push to `main` and all pull requests
+- **Steps**: checkout → Node.js 20 setup with npm cache → `npm ci` → `npm run lint` → `npm run test` → `npm run compile`
+- **Concurrency**: duplicate runs on the same branch are cancelled automatically
+
+CI is a merge gate — PRs with failing checks must not be merged.
+
 ## Package VSIX
 
 ```bash
@@ -65,7 +75,7 @@ code --install-extension phoenix-vscode-command-center-0.1.0.vsix --force
 ## VS Code Tasks
 
 | Task | Purpose |
-|------|---------|
+|------|----------|
 | `Command Center: Install` | `npm install` |
 | `Command Center: Compile` | `npm run compile` |
 | `Command Center: Watch` | `npm run watch` (background) |

--- a/.github/instructions/commandcenter-git-hygiene.instructions.md
+++ b/.github/instructions/commandcenter-git-hygiene.instructions.md
@@ -63,6 +63,15 @@ Run `npm run verify` before every PR push. All three steps must pass:
 2. `npm run test` — vitest
 3. `npm run compile` — build
 
+### CI checks
+
+- After creating/updating PR:
+  - Check GitHub Actions/workflow run status for the PR
+  - If any workflow/job fails, fetch logs and fix the root cause
+  - Re-run validations locally and re-trigger/recheck workflow runs
+  - Do not mark PR ready while required checks are failing
+- PR GitHub Actions checks are green (or explicitly understood/waived)
+
 ### PR size
 
 - Target ≤ 400 added/modified lines per PR

--- a/.github/instructions/commandcenter-project-structure.instructions.md
+++ b/.github/instructions/commandcenter-project-structure.instructions.md
@@ -4,7 +4,12 @@
 Phoenix-Agentic-VSCode-CommandCenter/
 ├── .github/
 │   ├── instructions/          # Copilot instruction files
-│   └── skills/                # Copilot skill files
+│   ├── skills/                # Copilot skill files
+│   └── workflows/             # CI/CD workflows
+│       ├── ci.yml             # CI — lint, test, compile on push/PR
+│       ├── cloud-agent-assign.yml  # Cloud agent gating and assignment
+│       ├── project-board-sync.yml  # Auto-add issues/PRs to project board
+│       └── sync-project-fields.yml # Signal label → project field sync
 ├── .vscode/
 │   ├── launch.json            # Extension Development Host debug config
 │   ├── settings.json          # Workspace settings
@@ -75,4 +80,5 @@ Phoenix-Agentic-VSCode-CommandCenter/
 - `test/` — vitest test files
 - `docs/` — Architecture and planning documentation
 - `out/` — Compiled output, not committed to git
+- `.github/workflows/` — CI/CD and project board automation workflows
 - Extension manifest and VS Code contribution points live in `package.json`

--- a/.github/skills/build-and-test/SKILL.md
+++ b/.github/skills/build-and-test/SKILL.md
@@ -8,7 +8,7 @@ description: Build, test, lint, and validate the Phoenix Command Center VS Code 
 ## Quick reference
 
 | Task | Command |
-|------|---------|
+|------|----------|
 | Install deps | `npm install` |
 | Type-check only | `npm run lint` |
 | Run tests | `npm run test` |
@@ -24,6 +24,10 @@ description: Build, test, lint, and validate the Phoenix Command Center VS Code 
 2. If only checking types: `npm run lint`
 3. If only running tests: `npm run test`
 4. For continuous development: `npm run watch` in background
+
+## CI pipeline
+
+GitHub Actions CI (`.github/workflows/ci.yml`) enforces the same quality gate automatically on every push to `main` and all pull requests. CI is a merge gate — PRs with failing checks must not be merged.
 
 ## Test details
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Compile
+        run: npm run compile

--- a/.github/workflows/cloud-agent-assign.yml
+++ b/.github/workflows/cloud-agent-assign.yml
@@ -19,7 +19,7 @@ on:
     types: [labeled]
 
 env:
-  PROJECT_NUMBER: 3
+  PROJECT_NUMBER: ${{ vars.CLOUD_AGENT_PROJECT_NUMBER || 3 }}
 
 jobs:
   assign-copilot:
@@ -192,7 +192,7 @@ jobs:
               owner,
               repo,
               issue_number,
-              body: `⛔ Cloud-agent assignment blocked.\n\n${reason}\n\n**Required steps:**\n1. Ensure the issue is on the [project board](https://github.com/users/rivie13/projects/3)\n2. Move the issue to **Ready** status\n3. Re-add the \`cloud-agent\` label`,
+              body: `⛔ Cloud-agent assignment blocked.\n\n${reason}\n\n**Required steps:**\n1. Ensure the issue is on the [project board](https://github.com/users/${context.repo.owner}/projects/${process.env.PROJECT_NUMBER})\n2. Move the issue to **Ready** status\n3. Re-add the \`cloud-agent\` label`,
             });
 
       # ── 3. Assign Copilot & update board status ─────────────────────
@@ -331,7 +331,7 @@ jobs:
                   base_branch: resolvedBaseBranch,
                   custom_instructions: '',
                   custom_agent: '',
-                  model: 'gpt-5.3-codex',
+                  model: 'gpt-4o',
                 },
                 headers: {
                   Accept: 'application/vnd.github+json',

--- a/.github/workflows/cloud-agent-assign.yml
+++ b/.github/workflows/cloud-agent-assign.yml
@@ -1,0 +1,456 @@
+# Securely assign Copilot coding agent when the `cloud-agent` label is added.
+# Guards:
+#   1. Actor must have write/maintain/admin permission (+ optional CLOUD_AGENT_ALLOWED_USERS allowlist).
+#   2. Issue must be in "Ready" status on the project board (prevents firing from Backlog).
+# On success:
+#   - Assigns Copilot coding agent to the issue.
+#   - Updates project board: Status → "In Progress", Work mode → "Cloud Agent".
+# Base branch resolution:
+#   1. Explicit override via issue label `base-branch:<branch>` (or `target-branch:<branch>`) or
+#      issue body line `Base branch: <branch>`.
+#   2. For task-like issues, if exactly one `feature/*` branch exists it is used; if multiple exist,
+#      a `feature/*` branch mentioned in the issue body is used.
+#   3. Falls back to repository default branch.
+
+name: Assign Copilot Cloud Agent
+
+on:
+  issues:
+    types: [labeled]
+
+env:
+  PROJECT_NUMBER: 3
+
+jobs:
+  assign-copilot:
+    if: github.event.label.name == 'cloud-agent'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+      actions: read
+    steps:
+      # ── 1. Permission guard ──────────────────────────────────────────
+      - name: Validate delegator permissions
+        id: guard
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const actor = context.actor;
+
+            let permission = 'none';
+            try {
+              const permissionResp = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username: actor,
+              });
+              permission = permissionResp.data.permission;
+            } catch (error) {
+              permission = 'none';
+            }
+
+            const allowedByPermission = ['admin', 'maintain', 'write'].includes(permission);
+
+            let allowlistRaw = '';
+            try {
+              const variableResp = await github.rest.actions.getRepoVariable({
+                owner,
+                repo,
+                name: 'CLOUD_AGENT_ALLOWED_USERS',
+              });
+              allowlistRaw = variableResp.data.value || '';
+            } catch (error) {
+              allowlistRaw = '';
+            }
+
+            const allowlist = (allowlistRaw || '')
+              .split(',')
+              .map((entry) => entry.trim())
+              .filter(Boolean);
+            const allowedByAllowlist = allowlist.length === 0 ? true : allowlist.includes(actor);
+
+            const allowed = allowedByPermission && allowedByAllowlist;
+
+            core.setOutput('allowed', String(allowed));
+            core.setOutput('permission', permission);
+            core.setOutput('allowlistEnabled', String(allowlist.length > 0));
+
+      - name: Reject unauthorized delegation
+        if: steps.guard.outputs.allowed != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            const actor = context.actor;
+            const permission = '${{ steps.guard.outputs.permission }}';
+            const allowlistEnabled = '${{ steps.guard.outputs.allowlistEnabled }}' === 'true';
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number,
+                name: 'cloud-agent',
+              });
+            } catch (error) {
+            }
+
+            const reason = allowlistEnabled
+              ? `@${actor} is not authorized by CLOUD_AGENT_ALLOWED_USERS or lacks required repository permission.`
+              : `@${actor} has '${permission}' permission; write/maintain/admin is required to delegate to Copilot.`;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `⛔ Cloud-agent delegation blocked. ${reason}`,
+            });
+
+      # ── 2. Project board "Ready" guard ───────────────────────────────
+      - name: Check project board status
+        if: steps.guard.outputs.allowed == 'true'
+        id: board
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}
+          script: |
+            const projectNumber = Number(process.env.PROJECT_NUMBER);
+            const issueNumber = context.payload.issue.number;
+
+            // Fetch this issue's project-board item and its Status value
+            const query = `
+              query($owner: String!, $repo: String!, $issueNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $issueNumber) {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { id number }
+                        fieldValueByName(name: "Status") {
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            const result = await github.graphql(query, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issueNumber,
+            });
+
+            const items = result.repository.issue.projectItems.nodes;
+            const boardItem = items.find(i => i.project.number === projectNumber);
+
+            if (!boardItem) {
+              core.setOutput('ready', 'false');
+              core.setOutput('reason', 'Issue is not on the project board. Add it to the board and set status to **Ready** first.');
+              return;
+            }
+
+            const currentStatus = boardItem.fieldValueByName?.name || 'No Status';
+
+            if (currentStatus !== 'Ready') {
+              core.setOutput('ready', 'false');
+              core.setOutput('reason', `Issue status is **${currentStatus}** — only issues in **Ready** status can be assigned to the cloud agent. Move it to Ready first.`);
+              return;
+            }
+
+            core.setOutput('ready', 'true');
+            core.setOutput('projectId', boardItem.project.id);
+            core.setOutput('itemId', boardItem.id);
+
+      - name: Reject non-ready issue
+        if: steps.guard.outputs.allowed == 'true' && steps.board.outputs.ready != 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number,
+                name: 'cloud-agent',
+              });
+            } catch (error) {}
+
+            const reason = `${{ steps.board.outputs.reason }}`;
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `⛔ Cloud-agent assignment blocked.\n\n${reason}\n\n**Required steps:**\n1. Ensure the issue is on the [project board](https://github.com/users/rivie13/projects/3)\n2. Move the issue to **Ready** status\n3. Re-add the \`cloud-agent\` label`,
+            });
+
+      # ── 3. Assign Copilot & update board status ─────────────────────
+      - name: Assign Copilot coding agent and update project board
+        if: steps.guard.outputs.allowed == 'true' && steps.board.outputs.ready == 'true'
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            const projectId = '${{ steps.board.outputs.projectId }}';
+            const itemId = '${{ steps.board.outputs.itemId }}';
+
+            // Assign Copilot coding agent to the issue
+            const defaultBranch = context.payload.repository?.default_branch || 'main';
+            const issueBody = context.payload.issue?.body || '';
+            const issueLabels = (context.payload.issue?.labels || [])
+              .map((label) => (typeof label === 'string' ? label : label?.name))
+              .filter(Boolean);
+
+            const normalizeBranchName = (value) => String(value || '')
+              .trim()
+              .replace(/^refs\/heads\//i, '');
+
+            const branchExists = async (branch) => {
+              if (!branch) return false;
+              try {
+                await github.rest.repos.getBranch({ owner, repo, branch });
+                return true;
+              } catch (error) {
+                return false;
+              }
+            };
+
+            const explicitCandidates = [];
+
+            for (const rawLabel of issueLabels) {
+              const label = String(rawLabel);
+              const lower = label.toLowerCase();
+              const prefixes = ['base-branch:', 'base_branch:', 'target-branch:', 'target_branch:'];
+              const prefix = prefixes.find((p) => lower.startsWith(p));
+              if (prefix) {
+                explicitCandidates.push(normalizeBranchName(label.slice(prefix.length)));
+              }
+            }
+
+            const bodyPatterns = [
+              /^\s*(?:base[\s_-]*branch|target[\s_-]*branch|branch)\s*:\s*([^\s`]+)/gim,
+              /--base-branch\s+([^\s`]+)/gim,
+            ];
+
+            for (const pattern of bodyPatterns) {
+              let match;
+              while ((match = pattern.exec(issueBody)) !== null) {
+                explicitCandidates.push(normalizeBranchName(match[1]));
+              }
+            }
+
+            const dedupedExplicit = [...new Set(explicitCandidates.filter(Boolean))];
+
+            let resolvedBaseBranch = '';
+            let baseBranchSource = '';
+
+            for (const candidate of dedupedExplicit) {
+              if (await branchExists(candidate)) {
+                resolvedBaseBranch = candidate;
+                baseBranchSource = 'issue override';
+                break;
+              }
+            }
+
+            if (!resolvedBaseBranch) {
+              const lowerLabels = issueLabels.map((label) => String(label).toLowerCase());
+              const isTaskLikeIssue = lowerLabels.some((label) =>
+                ['task', 'bug', 'refactor', 'test', 'docs', 'chore'].includes(label)
+              );
+
+              if (isTaskLikeIssue) {
+                const featureBranches = [];
+                for (let page = 1; page <= 3; page++) {
+                  const resp = await github.rest.repos.listBranches({
+                    owner,
+                    repo,
+                    per_page: 100,
+                    page,
+                  });
+
+                  if (!resp.data?.length) {
+                    break;
+                  }
+
+                  featureBranches.push(
+                    ...resp.data
+                      .map((branch) => branch.name)
+                      .filter((name) => name.startsWith('feature/'))
+                  );
+
+                  if (resp.data.length < 100) {
+                    break;
+                  }
+                }
+
+                const uniqueFeatureBranches = [...new Set(featureBranches)];
+
+                if (uniqueFeatureBranches.length === 1) {
+                  resolvedBaseBranch = uniqueFeatureBranches[0];
+                  baseBranchSource = 'single feature/* branch';
+                } else if (uniqueFeatureBranches.length > 1) {
+                  const mentioned = uniqueFeatureBranches.find((branch) =>
+                    issueBody.toLowerCase().includes(branch.toLowerCase())
+                  );
+                  if (mentioned) {
+                    resolvedBaseBranch = mentioned;
+                    baseBranchSource = 'feature branch mentioned in issue';
+                  }
+                }
+              }
+            }
+
+            if (!resolvedBaseBranch) {
+              resolvedBaseBranch = defaultBranch;
+              baseBranchSource = 'repository default';
+            }
+
+            const assignmentResp = await github.request(
+              'POST /repos/{owner}/{repo}/issues/{issue_number}/assignees',
+              {
+                owner,
+                repo,
+                issue_number,
+                assignees: ['copilot-swe-agent[bot]'],
+                agent_assignment: {
+                  target_repo: `${owner}/${repo}`,
+                  base_branch: resolvedBaseBranch,
+                  custom_instructions: '',
+                  custom_agent: '',
+                  model: 'gpt-5.3-codex',
+                },
+                headers: {
+                  Accept: 'application/vnd.github+json',
+                  'X-GitHub-Api-Version': '2022-11-28',
+                },
+              }
+            );
+
+            const assignees = assignmentResp?.data?.assignees || [];
+            const copilotAssigned = assignees.some((assignee) => {
+              const login = (assignee?.login || '').toLowerCase();
+              return login === 'copilot-swe-agent' || login === 'copilot-swe-agent[bot]';
+            });
+
+            if (!copilotAssigned) {
+              throw new Error('Copilot coding agent assignment was not applied by the API response.');
+            }
+
+            // Fetch project field definitions (Status + Work mode)
+            const fieldQuery = `
+              query($projectId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    fields(first: 30) {
+                      nodes {
+                        __typename
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options { id name }
+                        }
+                        ... on ProjectV2TextField {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            const fieldResult = await github.graphql(fieldQuery, { projectId });
+            const fields = (fieldResult.node.fields.nodes || []).filter((field) => field?.name);
+
+            const updateSingleSelectMutation = `
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(
+                  input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }
+                ) { projectV2Item { id } }
+              }`;
+
+            const updateTextMutation = `
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
+                updateProjectV2ItemFieldValue(
+                  input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { text: $text }
+                  }
+                ) { projectV2Item { id } }
+              }`;
+
+            const updates = [];
+
+            // Update Status → "In Progress"
+            const statusField = fields.find(f => f.name === 'Status');
+            if (statusField) {
+              const inProgress = statusField.options.find(o => o.name === 'In Progress');
+              if (inProgress) {
+                await github.graphql(updateSingleSelectMutation, {
+                  projectId, itemId,
+                  fieldId: statusField.id,
+                  optionId: inProgress.id,
+                });
+                updates.push('Status → **In Progress**');
+              }
+            }
+
+            // Update Work mode → "Cloud Agent"
+            const workModeField = fields.find((field) =>
+              ['work mode', 'work Mode', 'workmode'].includes((field.name || '').toLowerCase())
+            );
+            if (workModeField) {
+              if (workModeField.__typename === 'ProjectV2SingleSelectField') {
+                const cloudAgent = workModeField.options.find((option) => option.name === 'Cloud Agent');
+                if (cloudAgent) {
+                  await github.graphql(updateSingleSelectMutation, {
+                    projectId,
+                    itemId,
+                    fieldId: workModeField.id,
+                    optionId: cloudAgent.id,
+                  });
+                  updates.push('Work mode → **Cloud Agent**');
+                }
+              } else if (workModeField.__typename === 'ProjectV2TextField') {
+                await github.graphql(updateTextMutation, {
+                  projectId,
+                  itemId,
+                  fieldId: workModeField.id,
+                  text: 'Cloud Agent',
+                });
+                updates.push('Work mode → **Cloud Agent**');
+              }
+            }
+
+            const boardNote = updates.length > 0
+              ? `\n📋 Board updated: ${updates.join(', ')}`
+              : '';
+            const branchNote = `\n🌿 Base branch: \`${resolvedBaseBranch}\` (${baseBranchSource})`;
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number,
+              body: `🤖 Copilot coding agent has been assigned via the \`cloud-agent\` label.${boardNote}${branchNote}`,
+            });

--- a/.github/workflows/cloud-agent-assign.yml
+++ b/.github/workflows/cloud-agent-assign.yml
@@ -19,7 +19,7 @@ on:
     types: [labeled]
 
 env:
-  PROJECT_NUMBER: ${{ vars.CLOUD_AGENT_PROJECT_NUMBER || 3 }}
+  PROJECT_NUMBER: ${{ vars.CLOUD_AGENT_PROJECT_NUMBER || '3' }}
 
 jobs:
   assign-copilot:
@@ -122,7 +122,6 @@ jobs:
             const projectNumber = Number(process.env.PROJECT_NUMBER);
             const issueNumber = context.payload.issue.number;
 
-            // Fetch this issue's project-board item and its Status value
             const query = `
               query($owner: String!, $repo: String!, $issueNumber: Int!) {
                 repository(owner: $owner, name: $repo) {
@@ -192,7 +191,7 @@ jobs:
               owner,
               repo,
               issue_number,
-              body: `⛔ Cloud-agent assignment blocked.\n\n${reason}\n\n**Required steps:**\n1. Ensure the issue is on the [project board](https://github.com/users/${context.repo.owner}/projects/${process.env.PROJECT_NUMBER})\n2. Move the issue to **Ready** status\n3. Re-add the \`cloud-agent\` label`,
+              body: `⛔ Cloud-agent assignment blocked.\n\n${reason}\n\n**Required steps:**\n1. Ensure the issue is on the [project board](https://github.com/users/${owner}/projects/${process.env.PROJECT_NUMBER})\n2. Move the issue to **Ready** status\n3. Re-add the \`cloud-agent\` label`,
             });
 
       # ── 3. Assign Copilot & update board status ─────────────────────
@@ -208,7 +207,6 @@ jobs:
             const projectId = '${{ steps.board.outputs.projectId }}';
             const itemId = '${{ steps.board.outputs.itemId }}';
 
-            // Assign Copilot coding agent to the issue
             const defaultBranch = context.payload.repository?.default_branch || 'main';
             const issueBody = context.payload.issue?.body || '';
             const issueLabels = (context.payload.issue?.labels || [])
@@ -331,7 +329,7 @@ jobs:
                   base_branch: resolvedBaseBranch,
                   custom_instructions: '',
                   custom_agent: '',
-                  model: 'gpt-4o',
+                  model: 'gpt-5.3-codex',
                 },
                 headers: {
                   Accept: 'application/vnd.github+json',
@@ -350,7 +348,6 @@ jobs:
               throw new Error('Copilot coding agent assignment was not applied by the API response.');
             }
 
-            // Fetch project field definitions (Status + Work mode)
             const fieldQuery = `
               query($projectId: ID!) {
                 node(id: $projectId) {
@@ -402,7 +399,6 @@ jobs:
 
             const updates = [];
 
-            // Update Status → "In Progress"
             const statusField = fields.find(f => f.name === 'Status');
             if (statusField) {
               const inProgress = statusField.options.find(o => o.name === 'In Progress');
@@ -416,7 +412,6 @@ jobs:
               }
             }
 
-            // Update Work mode → "Cloud Agent"
             const workModeField = fields.find((field) =>
               ['work mode', 'work Mode', 'workmode'].includes((field.name || '').toLowerCase())
             );

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -1,0 +1,17 @@
+name: Sync to Project Board
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request:
+    types: [opened, reopened]
+
+jobs:
+  add-to-project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add to Phoenix Project Board
+        uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/users/rivie13/projects/3
+          github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -16,5 +16,5 @@ jobs:
       - name: Add to Phoenix Project Board
         uses: actions/add-to-project@v1.0.2
         with:
-          project-url: https://github.com/users/${{ github.repository_owner }}/projects/${{ vars.PROJECT_NUMBER || 3 }}
+          project-url: https://github.com/users/${{ github.repository_owner }}/projects/${{ vars.PROJECT_NUMBER || '3' }}
           github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}

--- a/.github/workflows/project-board-sync.yml
+++ b/.github/workflows/project-board-sync.yml
@@ -9,9 +9,12 @@ on:
 jobs:
   add-to-project:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Add to Phoenix Project Board
         uses: actions/add-to-project@v1.0.2
         with:
-          project-url: https://github.com/users/rivie13/projects/3
+          project-url: https://github.com/users/${{ github.repository_owner }}/projects/${{ vars.PROJECT_NUMBER || 3 }}
           github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}

--- a/.github/workflows/sync-project-fields.yml
+++ b/.github/workflows/sync-project-fields.yml
@@ -31,10 +31,10 @@ on:
           - create-signal-labels
 
 env:
-  PROJECT_NUMBER: 3
+  PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER || 3 }}
 
 jobs:
-  # ── Bootstrap: create or delete all signal labels ──────────────────
+  # ── Bootstrap: create all signal labels ─────────────────────────────
   manage-signal-labels:
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
@@ -186,7 +186,6 @@ jobs:
                 },
               },
               area: {
-                optional: true,
                 fieldNames: ['Area'],
                 options: {
                   'extension':  /\bextension\b/i,
@@ -242,26 +241,9 @@ jobs:
               return;
             }
 
-            if (fieldKey === 'workmode' && canonicalOptionKey === 'cloud-agent') {
-              const labels = (context.payload.issue.labels || [])
-                .map((entry) => typeof entry === 'string' ? entry : entry.name)
-                .filter(Boolean);
-
-              if (!labels.includes('cloud-agent')) {
-                await github.rest.issues.addLabels({
-                  owner,
-                  repo,
-                  issue_number: issueNumber,
-                  labels: ['cloud-agent'],
-                });
-                core.info(`Added real label "cloud-agent" to issue #${issueNumber}`);
-              } else {
-                core.info(`Issue #${issueNumber} already has label "cloud-agent"`);
-              }
-
-              await removeSignalLabel();
-              return;
-            }
+            // Note: set:workmode:cloud-agent does NOT auto-add the cloud-agent label.
+            // That label must be added manually by a human to correctly trigger the
+            // permission-guarded cloud-agent-assign workflow.
 
             if (fieldKey === 'workmode' && canonicalOptionKey === 'local-ide') {
               try {
@@ -430,6 +412,20 @@ jobs:
                 's': 'S',
                 'm': 'M',
                 'l': 'L',
+                'extension': 'extension',
+                'controller': 'controller',
+                'webview': 'webview',
+                'services': 'services',
+                'utils': 'utils',
+                'jarvis': 'jarvis',
+                'supervisor': 'supervisor',
+                'agent': 'agent',
+                'board': 'board',
+                'actions': 'actions',
+                'prs': 'prs',
+                'tests': 'tests',
+                'docs': 'docs',
+                'ci': 'ci',
               };
 
               const textValue = textByOption[canonicalOptionKey];

--- a/.github/workflows/sync-project-fields.yml
+++ b/.github/workflows/sync-project-fields.yml
@@ -1,0 +1,458 @@
+# Sync project board fields from transient "signal labels".
+#
+# MCP tools can only set labels — they cannot manage GitHub Projects V2 fields.
+# This workflow bridges that gap:
+#   1. Agent adds a signal label like `set:priority:p1` via MCP issue_write.
+#   2. This workflow fires, maps the label to the correct project field + option.
+#   3. Sets the field value via GraphQL updateProjectV2ItemFieldValue.
+#   4. Removes the signal label so only real labels remain.
+#
+# Signal label format: set:<field>:<value>
+#   - set:priority:p0 | p1 | p2 | p3
+#   - set:size:xs | s | m | l
+#   - set:workmode:cloud-agent | local-ide | cli-agent
+#   - set:status:backlog | ready | in-progress | in-review | done
+#   - set:area:<area-name>
+#
+# Also supports workflow_dispatch to bootstrap signal labels in the repo.
+
+name: Sync Project Fields
+
+on:
+  issues:
+    types: [labeled]
+  workflow_dispatch:
+    inputs:
+      action:
+        description: "Action to perform"
+        required: true
+        type: choice
+        options:
+          - create-signal-labels
+
+env:
+  PROJECT_NUMBER: 3
+
+jobs:
+  # ── Bootstrap: create or delete all signal labels ──────────────────
+  manage-signal-labels:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Manage signal labels
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const action = '${{ inputs.action }}';
+
+            const SIGNAL_LABELS = [
+              { name: 'set:priority:p0', color: 'B60205', description: 'Signal: set Priority → P0' },
+              { name: 'set:priority:p1', color: 'D93F0B', description: 'Signal: set Priority → P1' },
+              { name: 'set:priority:p2', color: 'FBCA04', description: 'Signal: set Priority → P2' },
+              { name: 'set:priority:p3', color: 'C2E0C6', description: 'Signal: set Priority → P3' },
+              { name: 'set:size:xs',     color: 'BFD4F2', description: 'Signal: set Size → XS' },
+              { name: 'set:size:s',      color: 'BFD4F2', description: 'Signal: set Size → S' },
+              { name: 'set:size:m',      color: 'BFD4F2', description: 'Signal: set Size → M' },
+              { name: 'set:size:l',      color: 'BFD4F2', description: 'Signal: set Size → L' },
+              { name: 'set:workmode:cloud-agent', color: 'D4C5F9', description: 'Signal: set Work mode → Cloud Agent' },
+              { name: 'set:workmode:local-ide',   color: 'D4C5F9', description: 'Signal: set Work mode → Local IDE' },
+              { name: 'set:workmode:cli-agent',   color: 'D4C5F9', description: 'Signal: set Work mode → CLI Agent' },
+              { name: 'set:area:extension',   color: '0075CA', description: 'Signal: set Area → extension' },
+              { name: 'set:area:controller',  color: '0075CA', description: 'Signal: set Area → controller' },
+              { name: 'set:area:webview',     color: '0075CA', description: 'Signal: set Area → webview' },
+              { name: 'set:area:services',    color: '0075CA', description: 'Signal: set Area → services' },
+              { name: 'set:area:utils',       color: '0075CA', description: 'Signal: set Area → utils' },
+              { name: 'set:area:jarvis',      color: '0075CA', description: 'Signal: set Area → jarvis' },
+              { name: 'set:area:supervisor',  color: '0075CA', description: 'Signal: set Area → supervisor' },
+              { name: 'set:area:agent',       color: '0075CA', description: 'Signal: set Area → agent' },
+              { name: 'set:area:board',       color: '0075CA', description: 'Signal: set Area → board' },
+              { name: 'set:area:actions',     color: '0075CA', description: 'Signal: set Area → actions' },
+              { name: 'set:area:prs',         color: '0075CA', description: 'Signal: set Area → prs' },
+              { name: 'set:area:tests',       color: '0075CA', description: 'Signal: set Area → tests' },
+              { name: 'set:area:docs',        color: '0075CA', description: 'Signal: set Area → docs' },
+              { name: 'set:area:ci',          color: '0075CA', description: 'Signal: set Area → ci' },
+              { name: 'set:status:backlog',     color: 'E4E669', description: 'Signal: set Status → Backlog' },
+              { name: 'set:status:ready',       color: 'E4E669', description: 'Signal: set Status → Ready' },
+              { name: 'set:status:in-progress', color: 'E4E669', description: 'Signal: set Status → In Progress' },
+              { name: 'set:status:in-review',   color: 'E4E669', description: 'Signal: set Status → In Review' },
+              { name: 'set:status:done',        color: 'E4E669', description: 'Signal: set Status → Done' },
+            ];
+
+            if (action === 'create-signal-labels') {
+              for (const label of SIGNAL_LABELS) {
+                try {
+                  await github.rest.issues.createLabel({ owner, repo, ...label });
+                  core.info(`Created label: ${label.name}`);
+                } catch (e) {
+                  if (e.status === 422) {
+                    core.info(`Label already exists: ${label.name}`);
+                  } else {
+                    core.warning(`Failed to create ${label.name}: ${e.message}`);
+                  }
+                }
+              }
+              core.info('All signal labels created.');
+            }
+
+  # ── Main: sync a signal label to a project field ───────────────────
+  sync-field:
+    if: >-
+      github.event_name == 'issues'
+      && startsWith(github.event.label.name, 'set:')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Update project field from signal label
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.PROJECT_BOARD_TOKEN }}
+          script: |
+            const label = context.payload.label.name;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = context.payload.issue.number;
+            const projectNumber = Number(process.env.PROJECT_NUMBER);
+
+            const removeSignalLabel = async () => {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  name: label,
+                });
+                core.info(`Removed signal label "${label}"`);
+              } catch (e) {
+                core.warning(`Failed to remove signal label "${label}": ${e.message}`);
+              }
+            };
+
+            // ── Parse signal label ──────────────────────────────────
+            const parts = label.split(':');
+            if (parts.length !== 3) {
+              core.warning(`Invalid signal label format: ${label} (expected set:<field>:<value>)`);
+              await removeSignalLabel();
+              return;
+            }
+            const normalizeKey = (value) => String(value || '')
+              .trim()
+              .toLowerCase()
+              .replace(/[_\s]+/g, '-');
+            const [, rawFieldKey, rawOptionKey] = parts;
+            const fieldKey = normalizeKey(rawFieldKey);
+            const optionKey = normalizeKey(rawOptionKey);
+
+            // ── Field → project field name + option matchers ────────
+            const FIELD_MAP = {
+              priority: {
+                fieldNames: ['Priority'],
+                options: {
+                  'p0': /p0/i,
+                  'p1': /p1/i,
+                  'p2': /p2/i,
+                  'p3': /p3/i,
+                },
+              },
+              size: {
+                fieldNames: ['Size'],
+                options: {
+                  'xs': /\bxs\b/i,
+                  's':  /\bs\b/i,
+                  'm':  /\bm\b/i,
+                  'l':  /\bl\b/i,
+                },
+              },
+              workmode: {
+                fieldNames: ['Work mode', 'Work Mode', 'Workmode'],
+                options: {
+                  'cloud-agent': /\bcloud\b.*\bagent\b|\bcloud\b/i,
+                  'local-ide':   /\blocal\b.*\bide\b|\blocal\b/i,
+                  'cli-agent':   /\bcli\b.*\bagent\b|\bcli.?agent\b|\bcli\b/i,
+                },
+              },
+              status: {
+                fieldNames: ['Status'],
+                options: {
+                  'backlog':     /backlog/i,
+                  'ready':       /\bready\b/i,
+                  'in-progress': /in.?progress/i,
+                  'in-review':   /in.?review/i,
+                  'done':        /\bdone\b/i,
+                },
+              },
+              area: {
+                optional: true,
+                fieldNames: ['Area'],
+                options: {
+                  'extension':  /\bextension\b/i,
+                  'controller': /\bcontroller\b/i,
+                  'webview':    /\bwebview\b/i,
+                  'services':   /\bservices?\b/i,
+                  'utils':      /\butils?\b/i,
+                  'jarvis':     /\bjarvis\b/i,
+                  'supervisor': /\bsupervisor\b/i,
+                  'agent':      /\bagent\b/i,
+                  'board':      /\bboard\b/i,
+                  'actions':    /\bactions\b/i,
+                  'prs':        /\bprs?\b/i,
+                  'tests':      /\btests?\b/i,
+                  'docs':       /\bdocs?\b/i,
+                  'ci':         /\bci\b/i,
+                },
+              },
+            };
+
+            const OPTION_ALIASES = {
+              workmode: {
+                local: 'local-ide',
+                localide: 'local-ide',
+                cli: 'cli-agent',
+                cliagent: 'cli-agent',
+              },
+              area: {
+                service: 'services',
+                util: 'utils',
+                pr: 'prs',
+                test: 'tests',
+                doc: 'docs',
+              },
+              status: {
+                inprogress: 'in-progress',
+                inreview: 'in-review',
+              },
+            };
+
+            const fieldConfig = FIELD_MAP[fieldKey];
+            if (!fieldConfig) {
+              core.warning(`Unknown field key "${fieldKey}" in signal label "${label}". Valid keys: ${Object.keys(FIELD_MAP).join(', ')}`);
+              await removeSignalLabel();
+              return;
+            }
+
+            const canonicalOptionKey = OPTION_ALIASES[fieldKey]?.[optionKey] || optionKey;
+            const optionMatcher = fieldConfig.options[canonicalOptionKey];
+            if (!optionMatcher) {
+              core.warning(`Unknown option "${optionKey}" for field "${fieldKey}". Valid options: ${Object.keys(fieldConfig.options).join(', ')}`);
+              await removeSignalLabel();
+              return;
+            }
+
+            if (fieldKey === 'workmode' && canonicalOptionKey === 'cloud-agent') {
+              const labels = (context.payload.issue.labels || [])
+                .map((entry) => typeof entry === 'string' ? entry : entry.name)
+                .filter(Boolean);
+
+              if (!labels.includes('cloud-agent')) {
+                await github.rest.issues.addLabels({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  labels: ['cloud-agent'],
+                });
+                core.info(`Added real label "cloud-agent" to issue #${issueNumber}`);
+              } else {
+                core.info(`Issue #${issueNumber} already has label "cloud-agent"`);
+              }
+
+              await removeSignalLabel();
+              return;
+            }
+
+            if (fieldKey === 'workmode' && canonicalOptionKey === 'local-ide') {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  name: 'cloud-agent',
+                });
+                core.info(`Removed real label "cloud-agent" from issue #${issueNumber}`);
+              } catch (e) {
+                core.info(`No real label "cloud-agent" to remove on issue #${issueNumber}`);
+              }
+            }
+
+            if (fieldKey === 'workmode' && canonicalOptionKey === 'cli-agent') {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  name: 'cloud-agent',
+                });
+                core.info(`Removed real label "cloud-agent" from issue #${issueNumber}`);
+              } catch (e) {
+                core.info(`No real label "cloud-agent" to remove on issue #${issueNumber}`);
+              }
+            }
+
+            // ── Find issue's project board item ─────────────────────
+            const itemQuery = `
+              query($owner: String!, $repo: String!, $issueNumber: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  issue(number: $issueNumber) {
+                    id
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { id number }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            const itemResult = await github.graphql(itemQuery, { owner, repo, issueNumber });
+            const issueNodeId = itemResult.repository.issue.id;
+            let items = itemResult.repository.issue.projectItems.nodes;
+            let boardItem = items.find(i => i.project.number === projectNumber);
+
+            if (!boardItem) {
+              const projectQuery = `
+                query($owner: String!, $projectNumber: Int!) {
+                  user(login: $owner) {
+                    projectV2(number: $projectNumber) { id }
+                  }
+                }`;
+              const projectResult = await github.graphql(projectQuery, { owner, projectNumber });
+              const projectId = projectResult.user.projectV2.id;
+
+              const addMutation = `
+                mutation($projectId: ID!, $contentId: ID!) {
+                  addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+                    item { id project { id number } }
+                  }
+                }`;
+              const addResult = await github.graphql(addMutation, { projectId, contentId: issueNodeId });
+              boardItem = addResult.addProjectV2ItemById.item;
+              core.info(`Added issue #${issueNumber} to project board`);
+            }
+
+            const projectId = boardItem.project.id;
+            const itemId = boardItem.id;
+
+            // ── Get field definitions ───────────────────────────────
+            const fieldQuery = `
+              query($projectId: ID!) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    fields(first: 30) {
+                      nodes {
+                        __typename
+                        ... on ProjectV2SingleSelectField {
+                          id
+                          name
+                          options { id name }
+                        }
+                        ... on ProjectV2TextField {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+              }`;
+
+            const fieldResult = await github.graphql(fieldQuery, { projectId });
+            const fields = (fieldResult.node.fields.nodes || []).filter((field) => field?.name);
+
+            const targetField = fields.find((field) =>
+              fieldConfig.fieldNames.some((name) => field.name.toLowerCase() === name.toLowerCase())
+            );
+            if (!targetField) {
+              core.warning(`Field "${fieldConfig.fieldNames.join(' / ')}" not found. Available: ${fields.map(f => f.name).join(', ')}`);
+              await removeSignalLabel();
+              return;
+            }
+
+            const updateSingleSelectMutation = `
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+                updateProjectV2ItemFieldValue(
+                  input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { singleSelectOptionId: $optionId }
+                  }
+                ) { projectV2Item { id } }
+              }`;
+
+            const updateTextMutation = `
+              mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
+                updateProjectV2ItemFieldValue(
+                  input: {
+                    projectId: $projectId
+                    itemId: $itemId
+                    fieldId: $fieldId
+                    value: { text: $text }
+                  }
+                ) { projectV2Item { id } }
+              }`;
+
+            let appliedValue = null;
+
+            if (targetField.__typename === 'ProjectV2SingleSelectField') {
+              const targetOption = targetField.options.find((option) => optionMatcher.test(option.name));
+              if (!targetOption) {
+                core.warning(`No matching option for "${canonicalOptionKey}" in "${targetField.name}". Available: ${targetField.options.map((option) => option.name).join(', ')}`);
+                await removeSignalLabel();
+                return;
+              }
+
+              await github.graphql(updateSingleSelectMutation, {
+                projectId,
+                itemId,
+                fieldId: targetField.id,
+                optionId: targetOption.id,
+              });
+              appliedValue = targetOption.name;
+            } else if (targetField.__typename === 'ProjectV2TextField') {
+              const textByOption = {
+                'cloud-agent': 'Cloud Agent',
+                'local-ide': 'Local IDE',
+                'cli-agent': 'CLI Agent',
+                'backlog': 'Backlog',
+                'ready': 'Ready',
+                'in-progress': 'In Progress',
+                'in-review': 'In Review',
+                'done': 'Done',
+                'p0': 'P0',
+                'p1': 'P1',
+                'p2': 'P2',
+                'p3': 'P3',
+                'xs': 'XS',
+                's': 'S',
+                'm': 'M',
+                'l': 'L',
+              };
+
+              const textValue = textByOption[canonicalOptionKey];
+              if (!textValue) {
+                core.warning(`Field "${targetField.name}" is a text field, but option "${canonicalOptionKey}" has no text mapping.`);
+                await removeSignalLabel();
+                return;
+              }
+
+              await github.graphql(updateTextMutation, {
+                projectId,
+                itemId,
+                fieldId: targetField.id,
+                text: textValue,
+              });
+              appliedValue = textValue;
+            } else {
+              core.warning(`Field "${targetField.name}" has unsupported type "${targetField.__typename}".`);
+              await removeSignalLabel();
+              return;
+            }
+
+            core.info(`✅ Set ${targetField.name} → ${appliedValue} for issue #${issueNumber}`);
+
+            // ── Remove the signal label ─────────────────────────────
+            await removeSignalLabel();

--- a/.github/workflows/sync-project-fields.yml
+++ b/.github/workflows/sync-project-fields.yml
@@ -31,7 +31,7 @@ on:
           - create-signal-labels
 
 env:
-  PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER || 3 }}
+  PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER || '3' }}
 
 jobs:
   # ── Bootstrap: create all signal labels ─────────────────────────────
@@ -241,9 +241,12 @@ jobs:
               return;
             }
 
-            // Note: set:workmode:cloud-agent does NOT auto-add the cloud-agent label.
-            // That label must be added manually by a human to correctly trigger the
-            // permission-guarded cloud-agent-assign workflow.
+            // ── Workmode side-effects: manage cloud-agent label ─────
+            // Note: set:workmode:cloud-agent only updates the board field.
+            // The privileged `cloud-agent` label must be added directly by
+            // an authorized user — this workflow intentionally does NOT
+            // auto-add it, to preserve the permission guard in
+            // cloud-agent-assign.yml.
 
             if (fieldKey === 'workmode' && canonicalOptionKey === 'local-ide') {
               try {
@@ -412,20 +415,20 @@ jobs:
                 's': 'S',
                 'm': 'M',
                 'l': 'L',
-                'extension': 'extension',
-                'controller': 'controller',
-                'webview': 'webview',
-                'services': 'services',
-                'utils': 'utils',
-                'jarvis': 'jarvis',
-                'supervisor': 'supervisor',
-                'agent': 'agent',
-                'board': 'board',
-                'actions': 'actions',
-                'prs': 'prs',
-                'tests': 'tests',
-                'docs': 'docs',
-                'ci': 'ci',
+                'extension': 'Extension',
+                'controller': 'Controller',
+                'webview': 'Webview',
+                'services': 'Services',
+                'utils': 'Utils',
+                'jarvis': 'Jarvis',
+                'supervisor': 'Supervisor',
+                'agent': 'Agent',
+                'board': 'Board',
+                'actions': 'Actions',
+                'prs': 'PRs',
+                'tests': 'Tests',
+                'docs': 'Docs',
+                'ci': 'CI',
               };
 
               const textValue = textByOption[canonicalOptionKey];


### PR DESCRIPTION
## Summary

Adds CI/CD GitHub Actions workflows to achieve parity with the other Phoenix repos (Backend, Interface, Website Frontend, Website Backend).

## Changes

- **`ci.yml`** — Runs on push to `main` and all PRs with concurrency control:
  - Lint (`npm run lint` — tsc typecheck)
  - Test (`npm run test` — vitest)
  - Compile (`npm run compile` — tsc build to `out/`)
- **`project-board-sync.yml`** — Auto-adds new issues and PRs to the Phoenix project board (#3)
- **`cloud-agent-assign.yml`** — Securely assigns Copilot coding agent when `cloud-agent` label is added, with:
  - Permission guard (write/maintain/admin required)
  - Project board "Ready" status guard
  - Smart base branch resolution (label override → feature branch detection → default)
  - Automatic board status update (Status → In Progress, Work mode → Cloud Agent)
- **`sync-project-fields.yml`** — Syncs transient signal labels (`set:priority:p1`, `set:area:webview`, etc.) to project board fields via GraphQL, with:
  - Area labels customized for Command Center areas: extension, controller, webview, services, utils, jarvis, supervisor, agent, board, actions, prs, tests, docs, ci
  - Bootstrap support via `workflow_dispatch` to create all signal labels

## Testing

- Workflow YAML validated against established patterns from Interface and Website Frontend repos
- Signal label area list customized from Command Center coding conventions valid areas

## Related

Closes #40